### PR TITLE
Documentation helpers

### DIFF
--- a/ursula/src/main/scala/com/alterationx10/ursula/args/Argument.scala
+++ b/ursula/src/main/scala/com/alterationx10/ursula/args/Argument.scala
@@ -1,5 +1,6 @@
 package com.alterationx10.ursula.args
 
+import com.alterationx10.ursula.doc._
 import zio.*
 
 /** Arguments are positional arguments passed to the command, and can be parsed
@@ -53,11 +54,6 @@ trait Argument[R] {
     */
   val default: Option[R] = Option.empty
 
-  /** Print documentation to the console.
-    */
-  def describeZIO: Task[Unit] = for {
-    _ <- Console.printLine(
-           s"\t$name\t$description${if required then " [required]" else ""}"
-         )
-  } yield ()
+  lazy val documentation: Documentation = ArgumentDoc(this)
+
 }

--- a/ursula/src/main/scala/com/alterationx10/ursula/args/Flag.scala
+++ b/ursula/src/main/scala/com/alterationx10/ursula/args/Flag.scala
@@ -1,7 +1,7 @@
 package com.alterationx10.ursula.args
 
 import com.alterationx10.ursula.extensions.*
-import com.alterationx10.ursula.doc.FlagDoc
+import com.alterationx10.ursula.doc.*
 import scala.annotation.tailrec
 import zio.*
 
@@ -172,35 +172,8 @@ trait Flag[R] {
       default.map(ZIO.succeed)
   } { identity }
 
-  private lazy val docGenerator: FlagDoc = FlagDoc(this)
+  lazy val documentation: Documentation = FlagDoc(this)
 
-  private final def printWhenDefined(
-      header: String
-  )(flags: Option[Seq[Flag[?]]]): Task[Unit] =
-    for {
-      _ <- ZIO.when(flags.exists(_.nonEmpty))(Console.printLine(header))
-      _ <- ZIO
-             .fromOption(flags)
-             .flatMap { s =>
-               ZIO.foreach(s)(f => Console.printLine(s"\t${f._sk}, ${f._lk}"))
-             }
-             .ignore
-    } yield ()
-
-  private final val printDocumentation: Task[Unit] = {
-    val argReq = if expectsArgument then "[arg]" else ""
-    val req    = if required then " [required]" else ""
-    for {
-      _ <- Console.printLine(s"\t${_sk}, ${_lk} $argReq \t$description$req")
-      _ <- printWhenDefined("Requires:")(dependsOn)
-      _ <- printWhenDefined("Conflicts with:")(exclusive)
-    } yield ()
-  }
-
-  /** A ZIO that prints documentation to the console
-    */
-  final def describeZIO: Task[Unit] =
-    ZIO.when(!hidden)(Console.printLine(docGenerator.txt.indented)).unit
 }
 
 trait BooleanFlag extends Flag[Unit] {

--- a/ursula/src/main/scala/com/alterationx10/ursula/args/Flag.scala
+++ b/ursula/src/main/scala/com/alterationx10/ursula/args/Flag.scala
@@ -1,6 +1,7 @@
 package com.alterationx10.ursula.args
 
 import com.alterationx10.ursula.extensions.*
+import com.alterationx10.ursula.doc.FlagDoc
 import scala.annotation.tailrec
 import zio.*
 
@@ -171,6 +172,8 @@ trait Flag[R] {
       default.map(ZIO.succeed)
   } { identity }
 
+  private lazy val docGenerator: FlagDoc = FlagDoc(this)
+
   private final def printWhenDefined(
       header: String
   )(flags: Option[Seq[Flag[?]]]): Task[Unit] =
@@ -197,7 +200,7 @@ trait Flag[R] {
   /** A ZIO that prints documentation to the console
     */
   final def describeZIO: Task[Unit] =
-    ZIO.when(!hidden)(printDocumentation).unit
+    ZIO.when(!hidden)(Console.printLine(docGenerator.txt.indented)).unit
 }
 
 trait BooleanFlag extends Flag[Unit] {

--- a/ursula/src/main/scala/com/alterationx10/ursula/command/Command.scala
+++ b/ursula/src/main/scala/com/alterationx10/ursula/command/Command.scala
@@ -3,6 +3,7 @@ package com.alterationx10.ursula.command
 import com.alterationx10.ursula.args.{Argument, Flag}
 import com.alterationx10.ursula.args.builtin.HelpFlag
 import com.alterationx10.ursula.errors.*
+import com.alterationx10.ursula.doc.*
 
 import scala.annotation.tailrec
 import zio.*
@@ -52,23 +53,13 @@ trait Command[A] {
     loop(args, Chunk.empty)
   }
 
+  lazy val documentation: Documentation = CommandDoc(this)
+
   /** Prints documentation
     * @return
     */
-  final def printHelp: Task[Unit] = for {
-    _ <- Console.printLine(s"$trigger:\t$description")
-    _ <- ZIO.when(flags.nonEmpty) {
-           Console.printLine(s"Flags:") *>
-             ZIO.foreach(flags)(_.describeZIO)
-         }
-    _ <- ZIO.when(arguments.nonEmpty) {
-           Console.printLine(s"Arguments:") *>
-             ZIO.foreach(arguments)(_.describeZIO)
-         }
-    _ <- Console.printLine(s"Usage:\n\t$usage")
-    _ <- Console.printLine("Examples:")
-    _ <- ZIO.foreach(examples)(e => Console.printLine(s"\t$e"))
-  } yield ()
+  final def printHelp: Task[Unit] =
+    Console.printLine(documentation.txt)
 
   private final def unrecognizedFlags(args: Chunk[String]): Boolean = {
     val flagTriggers: Seq[String] =

--- a/ursula/src/main/scala/com/alterationx10/ursula/doc/ArgumentDoc.scala
+++ b/ursula/src/main/scala/com/alterationx10/ursula/doc/ArgumentDoc.scala
@@ -1,0 +1,16 @@
+package com.alterationx10.ursula.doc
+
+import com.alterationx10.ursula.extensions.*
+import com.alterationx10.ursula.args.Argument
+import com.alterationx10.ursula.doc.*
+
+final case class ArgumentDoc(arg: Argument[?]) extends Documentation {
+  override lazy val txt: String = {
+    val sb = new StringBuilder()
+    sb.append(s"${arg.name}\t${arg.description}")
+    if (arg.required) then {
+      sb.append(" [required]")
+    }
+    sb.toString()
+  }
+}

--- a/ursula/src/main/scala/com/alterationx10/ursula/doc/CommandDoc.scala
+++ b/ursula/src/main/scala/com/alterationx10/ursula/doc/CommandDoc.scala
@@ -1,0 +1,30 @@
+package com.alterationx10.ursula.doc
+
+import com.alterationx10.ursula.extensions.*
+import com.alterationx10.ursula.command.Command
+
+final case class CommandDoc(cmd: Command[?]) extends Documentation {
+
+  override lazy val txt: String = {
+    val sb: StringBuilder = new StringBuilder()
+    sb.appendLine(s"${cmd.trigger}\t${cmd.description}")
+    if (cmd.flags.nonEmpty) then {
+      sb.appendLine("Flags:")
+      cmd.flags.sortBy(_.name).foreach { f =>
+        sb.appendLine(f.documentation.txt.indented)
+      }
+    }
+    if (cmd.arguments.nonEmpty) then {
+      sb.appendLine("Arguments:")
+      cmd.arguments.foreach(a => sb.appendLine(a.documentation.txt.indented))
+    }
+    sb.appendLine("Usage:")
+    sb.appendLine(s"\t${cmd.usage}")
+    if (cmd.examples.nonEmpty) then {
+      sb.appendLine("Examples:")
+      cmd.examples.foreach(e => sb.appendLine(s"\t$e"))
+    }
+    sb.toString()
+  }
+
+}

--- a/ursula/src/main/scala/com/alterationx10/ursula/doc/Documentation.scala
+++ b/ursula/src/main/scala/com/alterationx10/ursula/doc/Documentation.scala
@@ -1,0 +1,5 @@
+package com.alterationx10.ursula.doc
+
+trait Documentation {
+  def txt: String
+}

--- a/ursula/src/main/scala/com/alterationx10/ursula/doc/FlagDoc.scala
+++ b/ursula/src/main/scala/com/alterationx10/ursula/doc/FlagDoc.scala
@@ -1,0 +1,35 @@
+package com.alterationx10.ursula.doc
+
+import com.alterationx10.ursula.args.Flag
+import com.alterationx10.ursula.extensions.*
+import scala.collection.mutable.StringBuilder.apply
+
+final case class FlagDoc(flag: Flag[?]) {
+
+  lazy val txt: String = {
+    val sb: StringBuilder = new StringBuilder()
+    sb.append(s"${flag._sk}, ${flag._lk}")
+    if (flag.expectsArgument) then sb.append(" [arg]")
+    sb.append(s"\t${flag.description}")
+    if (flag.required) then sb.append(" [required")
+    sb.newLine
+    if (flag.dependsOn.nonEmpty) then {
+      sb.appendLine("Requires:")
+      flag.dependsOn.foreach { s =>
+        s.foreach { f =>
+          sb.appendLine(s"\t${f._sk}, ${f._lk}")
+        }
+      }
+    }
+    if (flag.exclusive.nonEmpty) then {
+      sb.appendLine("Conflicts with:")
+      flag.exclusive.foreach { s =>
+        s.foreach { f =>
+          sb.appendLine(s"\t${f._sk}, ${f._lk}")
+        }
+      }
+    }
+    sb.toString()
+  }
+
+}

--- a/ursula/src/main/scala/com/alterationx10/ursula/doc/FlagDoc.scala
+++ b/ursula/src/main/scala/com/alterationx10/ursula/doc/FlagDoc.scala
@@ -4,9 +4,9 @@ import com.alterationx10.ursula.args.Flag
 import com.alterationx10.ursula.extensions.*
 import scala.collection.mutable.StringBuilder.apply
 
-final case class FlagDoc(flag: Flag[?]) {
+final case class FlagDoc(flag: Flag[?]) extends Documentation {
 
-  lazy val txt: String = {
+  override lazy val txt: String = {
     val sb: StringBuilder = new StringBuilder()
     sb.append(s"${flag._sk}, ${flag._lk}")
     if (flag.expectsArgument) then sb.append(" [arg]")

--- a/ursula/src/main/scala/com/alterationx10/ursula/extensions/Extensions.scala
+++ b/ursula/src/main/scala/com/alterationx10/ursula/extensions/Extensions.scala
@@ -4,6 +4,10 @@ import zio.Chunk
 
 extension (s: String) {
   def chunked: Chunk[String] = Chunk.fromArray(s.split(" "))
+  def indented: String       =
+    s.split(System.lineSeparator())
+      .map(s => "\t" + s)
+      .mkString(System.lineSeparator())
 }
 
 extension [A](c: Chunk[A]) {
@@ -15,4 +19,12 @@ extension [A](c: Chunk[A]) {
 extension [A](o: Option[A]) {
   def :~(a: A): Option[A]         = o.orElse(Option(a))
   def :~(a: Option[A]): Option[A] = o.orElse(a)
+}
+
+extension (sb: StringBuilder) {
+  def newLine: StringBuilder =
+    sb.append(System.lineSeparator())
+
+  def appendLine(str: String): StringBuilder =
+    sb.append(str + System.lineSeparator())
 }


### PR DESCRIPTION
It seems most template engines are too much for the few formats likely to be supported. Twirl would be great, but leaves a bunch of whitespace that's unacceptable for this use case. Not sure if Scalate suffers the same issues, but also not sure that it works well with Scala 3...

This PR adds in some `Documentation` helper class that builds formatted documentation via a StringBuilder to render help for the console, and can later be updated to print markdown, html, etc... (this works toward #4 )