### PR TITLE
use withConsole to inject TTY locally when native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,4 +85,7 @@ lazy val ursulaTest = crossProject(JVMPlatform, NativePlatform)
 
 addCommandAlias("fmt", "all scalafmtSbt scalafmtAll")
 addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheckAll")
-addCommandAlias("fix", "++2.13.8; ursulaJVM/scalafixAll RemoveUnused; ursulaTestJVM/scalafixAll RemoveUnused")
+addCommandAlias(
+  "fix",
+  "++2.13.8; ursulaJVM/scalafixAll RemoveUnused; ursulaTestJVM/scalafixAll RemoveUnused"
+)

--- a/ursula-test/src/main/scala/com/alterationx10/ursula/extensions/UrsulaTestExtensions.scala
+++ b/ursula-test/src/main/scala/com/alterationx10/ursula/extensions/UrsulaTestExtensions.scala
@@ -1,6 +1,7 @@
 package com.alterationx10.ursula.extensions
 
 import zio.*
+import zio.Console.ConsoleLive
 
 trait UrsulaTestExtensions {
 
@@ -25,17 +26,23 @@ trait UrsulaTestExtensions {
   }
 
   implicit class ZIOTestExtension[R, E, A](zio: ZIO[R, E, A]) {
-    def testValue(implicit runtime: Runtime[R]): A = {
+    def testValue(implicit
+        runtime: Runtime[R],
+        console: Console = ConsoleLive
+    ): A = {
       Unsafe.unsafe { implicit unsafe =>
         runtime.unsafe
           .run(
-            zio
+            ZIO.withConsole(console)(zio)
           )
           .getOrThrowFiberFailure()
       }
     }
 
-    def runTestEither(implicit runtime: Runtime[R]): Either[E, A] = {
+    def runTestEither(implicit
+        runtime: Runtime[R],
+        console: Console = ConsoleLive
+    ): Either[E, A] = {
       Unsafe.unsafe { implicit unsafe =>
         runtime.unsafe
           .run(

--- a/ursula/shared/src/main/scala/com/alterationx10/ursula/UrsulaApp.scala
+++ b/ursula/shared/src/main/scala/com/alterationx10/ursula/UrsulaApp.scala
@@ -2,9 +2,8 @@ package com.alterationx10.ursula
 
 import com.alterationx10.ursula.command.Command
 import com.alterationx10.ursula.command.builtin.HelpCommand
-
 import zio.*
-import com.alterationx10.ursula.services.{Config, ConfigLive}
+import com.alterationx10.ursula.services.{Config, ConfigLive, TTY}
 import com.alterationx10.ursula.command.builtin.ConfigCommand
 
 trait UrsulaApp extends ZIOAppDefault {
@@ -102,8 +101,10 @@ trait UrsulaApp extends ZIOAppDefault {
   /** The entry point to the CLI, pre-wired
     */
   override final def run: ZIO[ZIOAppArgs & Scope, Any, Any] =
-    program.provideSome[ZIOAppArgs & Scope](
-      commandLayer ++ ConfigLive.live(configDirectory, configFile)
-    )
+    ZIO
+      .withConsole(TTY.getPlatformConsole)(program)
+      .provideSome[ZIOAppArgs & Scope](
+        commandLayer ++ ConfigLive.live(configDirectory, configFile)
+      )
 
 }

--- a/ursula/shared/src/main/scala/com/alterationx10/ursula/command/Command.scala
+++ b/ursula/shared/src/main/scala/com/alterationx10/ursula/command/Command.scala
@@ -7,7 +7,7 @@ import com.alterationx10.ursula.doc.*
 
 import scala.annotation.tailrec
 import zio.*
-import com.alterationx10.ursula.services.{Config, TTY}
+import com.alterationx10.ursula.services.Config
 
 trait Command {
 
@@ -112,7 +112,7 @@ trait Command {
     * @return
     */
   final def printHelp: Task[Unit] =
-    TTY.printLine(documentation.txt)
+    Console.printLine(documentation.txt)
 
   private final def unrecognizedFlags(args: Chunk[String]): Boolean = {
     val flagTriggers: Seq[String] =
@@ -141,7 +141,7 @@ trait Command {
     ZIO.cond(!predicate, (), error).when(strict).unit
 
   private final def printArgs(args: Chunk[String]): Task[Unit] =
-    TTY.printLine(s"> ${args.mkString(" ")}")
+    Console.printLine(s"> ${args.mkString(" ")}")
 
   private final val printHelpfulError
       : Chunk[String] => CommandException => Task[Unit] =

--- a/ursula/shared/src/main/scala/com/alterationx10/ursula/command/builtin/ConfigCommand.scala
+++ b/ursula/shared/src/main/scala/com/alterationx10/ursula/command/builtin/ConfigCommand.scala
@@ -5,7 +5,7 @@ import com.alterationx10.ursula.args.Argument
 import com.alterationx10.ursula.args.Flag
 import zio.*
 import com.alterationx10.ursula.args.BooleanFlag
-import com.alterationx10.ursula.services.{Config, TTY}
+import com.alterationx10.ursula.services.Config
 
 case object SetFlag extends BooleanFlag {
 
@@ -89,8 +89,8 @@ object ConfigCommand extends Command {
     _     <- Config
                .get(_args.head)
                .flatMap {
-                 case Some(v) => TTY.printLine(v)
-                 case None    => TTY.printLine(s"${_args.head} not set!")
+                 case Some(v) => Console.printLine(v)
+                 case None    => Console.printLine(s"${_args.head} not set!")
                }
                .when(GetFlag.isPresent(args))
     _     <- Config

--- a/ursula/shared/src/main/scala/com/alterationx10/ursula/command/builtin/HelpCommand.scala
+++ b/ursula/shared/src/main/scala/com/alterationx10/ursula/command/builtin/HelpCommand.scala
@@ -3,9 +3,7 @@ package com.alterationx10.ursula.command.builtin
 import com.alterationx10.ursula.args.{Argument, Flag}
 import com.alterationx10.ursula.args.builtin.HelpFlag
 import com.alterationx10.ursula.command.Command
-import com.alterationx10.ursula.services.TTY
 import zio.*
-
 
 case class HelpCommand(commands: Seq[Command], isDefault: Boolean)
     extends Command {
@@ -32,15 +30,15 @@ case class HelpCommand(commands: Seq[Command], isDefault: Boolean)
   override val arguments: Seq[Argument[?]] = Seq.empty
 
   override def action(args: Chunk[String]): Task[Unit] = for {
-    _ <- TTY.printLine("The CLI supports the following commands:")
+    _ <- Console.printLine("The CLI supports the following commands:")
     _ <- ZIO.foreach(commands.filter(!_.hidden))(c =>
-           TTY.printLine(s"${c.trigger}: ${c.description}")
+           Console.printLine(s"${c.trigger}: ${c.description}")
          )
     _ <- ZIO.when(!this.hidden)(
-           TTY.printLine(s"${this.trigger}: ${this.description}")
+           Console.printLine(s"${this.trigger}: ${this.description}")
          )
     _ <-
-      TTY.printLine(
+      Console.printLine(
         s"use [cmd] ${HelpFlag._sk}, ${HelpFlag._lk} for cmd-specific help"
       )
   } yield ()

--- a/ursula/shared/src/main/scala/com/alterationx10/ursula/errors/UrsulaException.scala
+++ b/ursula/shared/src/main/scala/com/alterationx10/ursula/errors/UrsulaException.scala
@@ -1,10 +1,9 @@
 package com.alterationx10.ursula.errors
 
-import com.alterationx10.ursula.services.TTY
-import zio.Task
+import zio.*
 
 trait UrsulaException extends Exception {
   val msg: String
   override def getMessage(): String = msg
-  def printMessageZIO: Task[Unit]   = TTY.printLine(getMessage)
+  def printMessageZIO: Task[Unit]   = Console.printLine(getMessage)
 }

--- a/ursula/shared/src/main/scala/com/alterationx10/ursula/services/TTY.scala
+++ b/ursula/shared/src/main/scala/com/alterationx10/ursula/services/TTY.scala
@@ -1,14 +1,18 @@
 package com.alterationx10.ursula.services
 
 import zio.*
+import zio.Console.ConsoleLive
+import zio.internal.Platform
 
 import java.io.IOException
 
 object TTY {
 
+  def getPlatformConsole: Console =
+    if (Platform.isNative) TTYLive else ConsoleLive
+
   object TTYLive extends Console {
 
-    println()
     override def print(
         line: => Any
     )(implicit trace: Trace): IO[IOException, Unit] = ZIO

--- a/ursula/shared/src/test/scala/com/alterationx10/ursula/UrsulaAppSpec.scala
+++ b/ursula/shared/src/test/scala/com/alterationx10/ursula/UrsulaAppSpec.scala
@@ -7,11 +7,12 @@ import utest.*
 object UrsulaAppSpec extends TestSuite {
 
   object TestProgram extends UrsulaApp {
-    lazy val tmpDir: Path = os.temp.dir(prefix = "ursula-test-UrsulaAppSpec")
-    lazy val tmpConfig: Path = os.temp(contents = Source.WritableSource("{}"), dir = tmpDir)
+    lazy val tmpDir: Path                     = os.temp.dir(prefix = "ursula-test-UrsulaAppSpec")
+    lazy val tmpConfig: Path                  =
+      os.temp(contents = Source.WritableSource("{}"), dir = tmpDir)
     override lazy val configDirectory: String = tmpDir.toString()
-    override lazy val configFile: String = tmpConfig.last
-    override val commands: Seq[Command] = Seq.empty
+    override lazy val configFile: String      = tmpConfig.last
+    override val commands: Seq[Command]       = Seq.empty
   }
 
   override def tests: Tests = Tests {

--- a/ursula/shared/src/test/scala/com/alterationx10/ursula/command/CommandSpec.scala
+++ b/ursula/shared/src/test/scala/com/alterationx10/ursula/command/CommandSpec.scala
@@ -8,7 +8,7 @@ import com.alterationx10.ursula.errors.MissingFlagsException
 import com.alterationx10.ursula.errors.ConflictingFlagsException
 import com.alterationx10.ursula.errors.UnrecognizedFlagException
 import com.alterationx10.ursula.extensions.*
-import com.alterationx10.ursula.services.{Config, ConfigLive}
+import com.alterationx10.ursula.services.{Config, ConfigLive, TTY}
 import utest.*
 
 // A <-> B Conflict
@@ -78,7 +78,8 @@ object CommandSpec extends TestSuite with UrsulaTestExtensions {
   implicit val rt: Runtime.Scoped[Config] =
     ConfigLive.temp.testRuntime
 
-  override def tests: Tests = Tests {
+  implicit val cnsl: Console = TTY.getPlatformConsole
+  override def tests: Tests  = Tests {
 
     test("should succeed when flags are given correctly") {
       TestCommand.processedAction(goodCommand).testValue


### PR DESCRIPTION
By using `ZIO.withConsole(TTY.getPlatformConsole)(program)`, we can inject TTY as the console for the app when native, so the user doesn't have to mentally context shift between `Console.stuff` and `TTY.stuff`.